### PR TITLE
Ported over map lookup service definition

### DIFF
--- a/srv/MapLookup.srv
+++ b/srv/MapLookup.srv
@@ -1,0 +1,20 @@
+# Name of the robot, will be used to determine which mission to use for the lookup
+string robot_name
+# Sensor type/frame (S) of the requested sensor point (NCAMERA, LIDAR or IMU)
+string sensor_type
+# Timestamp of desired robot pose corresponding to the requested points
+time timestamp
+# Points in sensor frame (S)
+geometry_msgs/Point p_S
+---
+# Status of the map lookup, options are:
+#  0 - Success
+#  1 - No such robot name / mission
+#  2 - No such sensor
+#  3 - Timestamp outside range of mission (Upper bound, lookup might work later)
+#  4 - Timestamp outside range of mission (Lower bound, Lookup will never work)
+int32 status
+# Points in global map frame (G)
+geometry_msgs/Point p_G
+# Sensor origin in global map frame (G)
+geometry_msgs/Point sensor_p_G


### PR DESCRIPTION
Porting over map lookup service needed for the new maplab server update to enable external queries from @mfehr.